### PR TITLE
Add PaperG Puppet Debian bootstrap script

### DIFF
--- a/debian-paperg.sh
+++ b/debian-paperg.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+
+# This bootstraps Puppet on Debian
+set -e
+
+# Do the initial apt-get update
+echo "Initial apt-get update..."
+apt-get update >/dev/null
+
+# Older versions of Debian don't have lsb_release by default, so 
+# install that if we have to.
+which lsb_release || apt-get install -y lsb-release
+
+# Load up the release information
+DISTRIB_CODENAME=$(lsb_release -c -s)
+
+REPO_DEB_URL="http://apt.puppetlabs.com/puppetlabs-release-${DISTRIB_CODENAME}.deb"
+
+#--------------------------------------------------------------------
+# NO TUNABLES BELOW THIS POINT
+#--------------------------------------------------------------------
+if [ "$EUID" -ne "0" ]; then
+  echo "This script must be run as root." >&2
+  exit 1
+fi
+
+# Install wget if we have to (some older Debian versions)
+echo "Installing wget..."
+apt-get install -y wget >/dev/null
+
+# Install the PuppetLabs repo
+echo "Configuring PuppetLabs repo..."
+repo_deb_path=$(mktemp)
+wget --output-document="${repo_deb_path}" "${REPO_DEB_URL}" 2>/dev/null
+dpkg -i "${repo_deb_path}" >/dev/null
+apt-get update >/dev/null
+
+# Install Puppet
+echo "Installing Puppet..."
+DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install puppet >/dev/null
+
+echo "Puppet installed!"
+
+
+echo "Customizing puppet.conf for PaperG"
+grep paperg /etc/puppet/puppet.conf || sed -i '/\[main\]/a server=puppet.paperg.com\npluginsync=true' /etc/puppet/puppet.conf
+
+echo "Configuring puppet to start at boot"
+sed -i 's/START=no/START=yes/' /etc/default/puppet
+
+echo "Restarting Puppet!"
+service puppet restart
+


### PR DESCRIPTION
This adds the default puppet configurations to boot a debian
machine and prepare it to be provisioned via puppet.
