### PR TITLE
Ensure puppet starts on boot

### DIFF
--- a/debian-paperg.sh
+++ b/debian-paperg.sh
@@ -46,7 +46,13 @@ echo "Customizing puppet.conf for PaperG"
 grep paperg /etc/puppet/puppet.conf || sed -i '/\[main\]/a server=puppet.paperg.com\npluginsync=true' /etc/puppet/puppet.conf
 
 echo "Configuring puppet to start at boot"
-sed -i 's/START=no/START=yes/' /etc/default/puppet
+DEFAULT_FILE="/etc/default/puppet"
+if [ -f $DEFAULT_FILE ] && grep -v -Fxq "START=no" $DEFAULT_FILE
+then
+    sed -i 's/START=no/START=yes/' $DEFAULT_FILE
+else
+    echo 'START=yes' >> $DEFAULT_FILE
+fi
 
 echo "Restarting Puppet!"
 service puppet restart


### PR DESCRIPTION
This changes the conditions for updating the default
file to ensure that puppet starts on boot. Using debain 8
the /etc/default/puppet didn't exist causing the script to file
when attempting to write to the file. This ensures that 
/etc/default/puppet exists and that it doesn't already 
contain the string START=yes.
