### PR TITLE
Setup continuous testing and deployment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,17 @@
+machine:
+  pre:
+    # install bash syntax checker 'shellcheck'
+    - sudo apt-get update
+    - sudo apt-get -y install shellcheck
+
+test:
+  override:
+    - shellcheck debian-paperg.sh
+
+deployment:
+  release:
+    branch: master
+    owner: makethunder
+    commands:
+      - s3path="s3://s3.aws.paperg.com/circleci/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/"
+      - aws s3 cp debian-paperg.sh "${s3path}/debian-paperg.sh"

--- a/debian-paperg.sh
+++ b/debian-paperg.sh
@@ -17,7 +17,7 @@ DISTRIB_CODENAME=$(lsb_release -c -s)
 REPO_DEB_URL="http://apt.puppetlabs.com/puppetlabs-release-${DISTRIB_CODENAME}.deb"
 
 # If wheezy ensure that dotdeb is included to install php 5.5
-if [ "$DISTRIB_CODENAME" == "wheezy" ]; then                                    
+if [ "$DISTRIB_CODENAME" = "wheezy" ]; then                                    
     wget https://www.dotdeb.org/dotdeb.gpg -P /tmp                              
     apt-key add /tmp/dotdeb.gpg                                                                                                                                      
 


### PR DESCRIPTION
This sets up continuous testing using the 'shellcheck' bash/sh script analyst tool as well as publishing the checked debian-paperg.sh to our s3 bucket. This allows us to continuously publish our puppet boot-strap script that will be used to provision new hosts.

@kian 
