### PR TITLE
Switch to posix compliant syntax

### DIFF
--- a/debian-paperg.sh
+++ b/debian-paperg.sh
@@ -32,7 +32,7 @@ fi
 #--------------------------------------------------------------------
 # NO TUNABLES BELOW THIS POINT
 #--------------------------------------------------------------------
-if [ "$EUID" -ne "0" ]; then
+if [ "$(id -u)" != "0" ]; then
   echo "This script must be run as root." >&2
   exit 1
 fi


### PR DESCRIPTION
EUID is not posix compliant and the dash shell complains when the script is ran. 
This ensures that our script is posix compliant.

@kian 
