### PR TITLE
Remove S3 upload

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,3 @@ machine:
 test:
   override:
     - shellcheck debian-paperg.sh
-
-deployment:
-  release:
-    branch: master
-    owner: makethunder
-    commands:
-      - aws s3 cp debian-paperg.sh "s3://s3.aws.paperg.com/circleci/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/"
-      - aws s3api put-object-acl --acl public-read --bucket s3.aws.paperg.com --key "circleci/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/debian-paperg.sh"


### PR DESCRIPTION
Since the file is published to github publicly we no longer need to publish 
this to s3.